### PR TITLE
[Prestashop 1.7.6] Fixing bugs detected in Prestashop 1.7.6

### DIFF
--- a/controllers/front/archive.php
+++ b/controllers/front/archive.php
@@ -13,7 +13,7 @@ class xipblogArchiveModuleFrontController extends xipblogMainModuleFrontControll
        	$this->rewrite = Tools::getValue('rewrite');
        	$subpage_type = Tools::getValue('subpage_type');
        	$p = Tools::getValue('page');
-		$this->p = isset($p) && !empty($p) ? $p : 1;
+		$this->p = isset($p) && !empty($p) ? intval($p) : 1;
 		$id_identity = Tools::getValue('id');
 		if(!isset($id_identity) || empty($id_identity)){
 			$this->id_identity = (int)xipcategoryclass::get_the_id($this->rewrite,$this->page_type);
@@ -147,7 +147,7 @@ class xipblogArchiveModuleFrontController extends xipblogMainModuleFrontControll
         $pagination
             ->setPage($this->p)
             ->setPagesCount(
-                ceil($this->nbProducts / $this->n)
+                intval(ceil($this->nbProducts / $this->n))
             )
         ;
         $totalItems = $this->nbProducts;
@@ -167,14 +167,15 @@ class xipblogArchiveModuleFrontController extends xipblogMainModuleFrontControll
     }
     public function getBreadcrumbLinks()
     {
+        $id_lang = (int)$this->context->language->id;
+        
         $breadcrumb = parent::getBreadcrumbLinks();
-        $blog_title = Configuration::get(xipblog::$xipblogshortname."meta_title");
+        $blog_title = Configuration::get(xipblog::$xipblogshortname."meta_title",$id_lang);
         $breadcrumb['links'][] = array(
             'title' => $blog_title,
             'url' => xipblog::XipBlogLink(),
         );
-        $id_lang = (int)$this->context->language->id;
-
+        
         if(isset($this->blogcategory->title[$id_lang]) && !empty($this->blogcategory->title[$id_lang])){
         	$category_name = $this->blogcategory->title[$id_lang];
         }elseif(isset($this->blogcategory->name[$id_lang]) && !empty($this->blogcategory->name[$id_lang])){
@@ -182,16 +183,19 @@ class xipblogArchiveModuleFrontController extends xipblogMainModuleFrontControll
         }else{
         	$category_name = '';
         }
-        $params = array();
-        $params['id'] = $this->blogcategory->id_xipcategory ? $this->blogcategory->id_xipcategory : 0;
-        $params['rewrite'] = (isset($this->blogcategory->link_rewrite[$id_lang]) && !empty($this->blogcategory->link_rewrite[$id_lang])) ? $this->blogcategory->link_rewrite[$id_lang] : 'category_blog_post';
-        $params['page_type'] = 'category';
-        $params['subpage_type'] = 'post';
-		$category_url = xipblog::XipBlogCategoryLink($params);
-        $breadcrumb['links'][] = array(
-            'title' => $category_name,
-            'url' => $category_url,
-        );
+
+        if ($category_name != '') {
+            $params = array();
+            $params['id'] = $this->blogcategory->id_xipcategory ? $this->blogcategory->id_xipcategory : 0;
+            $params['rewrite'] = (isset($this->blogcategory->link_rewrite[$id_lang]) && !empty($this->blogcategory->link_rewrite[$id_lang])) ? $this->blogcategory->link_rewrite[$id_lang] : 'category_blog_post';
+            $params['page_type'] = 'category';
+            $params['subpage_type'] = 'post';
+            $category_url = xipblog::XipBlogCategoryLink($params);
+            $breadcrumb['links'][] = array(
+                'title' => $category_name,
+                'url' => $category_url,
+            );
+        }
 
         return $breadcrumb;
     }

--- a/controllers/front/single.php
+++ b/controllers/front/single.php
@@ -115,8 +115,10 @@ class xipblogSingleModuleFrontController extends xipblogMainModuleFrontControlle
     public function getBreadcrumbLinks()
     {
 
+        $id_lang = (int)$this->context->language->id;
+
         $breadcrumb = parent::getBreadcrumbLinks();
-        $blog_title = Configuration::get(xipblog::$xipblogshortname."meta_title");
+        $blog_title = Configuration::get(xipblog::$xipblogshortname."meta_title", $id_lang);
         $breadcrumb['links'][] = array(
             'title' => $blog_title,
             'url' => xipblog::XipBlogLink(),

--- a/views/templates/front/default/archive.tpl
+++ b/views/templates/front/default/archive.tpl
@@ -98,9 +98,9 @@
 	</div>
 	{/if}
 	</section>
+	{include file="module:xipblog/views/templates/front/default/pagination.tpl"}
 {/block}
-{include file="module:xipblog/views/templates/front/default/pagination.tpl"}
-{/block}
+
 {block name="left_column"}
 	{assign var="layout_column" value=$layout|replace:'layouts/':''|replace:'.tpl':''|strval}
 	{if ($layout_column == 'layout-left-column')}

--- a/xipblog.php
+++ b/xipblog.php
@@ -267,7 +267,7 @@ class xipblog extends Module implements WidgetInterface
                 ),
                 'xipblog-archive-wid-module' => array(
                     'controller' =>  'archive',
-                    'rule' =>        $main_slug.'/'.$category_slug.'/{rewrite}'.$postfix_slug,
+                    'rule' =>        $main_slug.'/'.$category_slug.'/{id}_{rewrite}'.$postfix_slug,
                     'keywords' => array(
                         'id'   =>   array('regexp' => '[0-9]+', 'param' => 'id'),
                         'rewrite'       =>   array('regexp' => '[_a-zA-Z0-9-\pL]*','param' => 'rewrite'),
@@ -309,7 +309,7 @@ class xipblog extends Module implements WidgetInterface
                 ),
                 'xipblog-tag-wid-module' => array(
                     'controller' =>  'archive',
-                    'rule' =>        $main_slug.'/'.$tag_slug.'/{rewrite}'.$postfix_slug,
+                    'rule' =>        $main_slug.'/'.$tag_slug.'/{id}_{rewrite}'.$postfix_slug,
                     'keywords' => array(
                         'id'   =>   array('regexp' => '[0-9]+', 'param' => 'id'),
                         'rewrite'       =>   array('regexp' => '[_a-zA-Z0-9-\pL]*','param' => 'rewrite'),
@@ -349,7 +349,7 @@ class xipblog extends Module implements WidgetInterface
                 ),
                 'xipblog-single-wid-module' => array(
                     'controller' =>  'single',
-                    'rule' =>        $main_slug.'/'.$single_slug.'/{rewrite}'.$postfix_slug,
+                    'rule' =>        $main_slug.'/'.$single_slug.'/{id}_{rewrite}'.$postfix_slug,
                     'keywords' => array(
                         'id' =>   array('regexp' => '[0-9]+','param' => 'id'),
                         'rewrite' =>   array('regexp' => '[_a-zA-Z0-9-\pL]*','param' => 'rewrite'),


### PR DESCRIPTION
Thanks for developed XipBlog. I have added to my store. I am using version 1.7.6 and I detected some issues for this version that I fixed. I share it because maybe is useful for more people. 

I do pull request to master branch because I don't see connection between version 2.0.2 and master and there is not an specific development branch.

Commit done:

- Fixed problem with SEO urls. Format: {id}_{rewrite} (xipblog.php).
- Fixed debug error while debugging with pagination (controllers/front/archive.php).
- Fixed pagination. It was not being shown (views/templates/front/default/archive.tpl).
- Fixed breadcrumb title. It was not being shown. It was an error with language (controllers/front/archive.php, controllers/front/single.php).
- Not showing breadcrumb category if it is not selected, for example in main blog page (controllers/front/archive.php).

Regards